### PR TITLE
Ensure `expectedAction` is checked when looking for a matching proof.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Add `extendDocumentLoader` for adding a custom document loader that extend
   `documentLoader` to load other documents.
 
+### Fixed
+- Ensure `expectedAction` is checked when looking for a matching proof,
+  not `capabilityAction`.
+
 ## 4.0.0 - 2021-04-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @digitalbazaar/zcapld ChangeLog
 
-## 4.1.0 - 2021-xx-xx
+## 5.0.0 - 2021-xx-xx
 
 ### Added
 - Expose `ZCAP_CONTEXT` in `constants` as a convenience.
@@ -8,6 +8,14 @@
   `ZCAP_CONTEXT`.
 - Add `extendDocumentLoader` for adding a custom document loader that extend
   `documentLoader` to load other documents.
+
+### Changed
+- **BREAKING**: LD capability invocation proofs now require `invocationTarget`
+  to be set in order for `match()` to find proofs based on `expectedTarget`.
+  This helps ensure that the proof creator's intended `invocationTarget` is
+  declared (important for systems that support RESTful attenuation) and it
+  enables more efficient proof verification when documents include multiple
+  capability invocation proofs that may have different invocation targets.
 
 ### Fixed
 - Ensure `expectedAction` is checked when looking for a matching proof,

--- a/lib/CapabilityInvocation.js
+++ b/lib/CapabilityInvocation.js
@@ -167,8 +167,8 @@ module.exports = class CapabilityInvocation extends ControllerProofPurpose {
   }
 
   async match(proof, {document, documentLoader, expansionMap}) {
-    const {capabilityAction} = this;
+    const {expectedAction} = this;
     return await super.match(proof, {document, documentLoader, expansionMap}) &&
-      (!capabilityAction || capabilityAction === proof.capabilityAction);
+      (expectedAction === proof.capabilityAction);
   }
 };

--- a/lib/CapabilityInvocation.js
+++ b/lib/CapabilityInvocation.js
@@ -25,6 +25,9 @@ module.exports = class CapabilityInvocation extends ControllerProofPurpose {
    *   added/referenced in a created proof.
    * @param [capabilityAction] {string} the capability action that is
    *   to be added to a proof.
+   * @param [invocationTarget] {string} the invocation target to use; this
+   *   is required and can be used to attenuate the capability's invocation
+   *   target if the verifier supports target attentuation.
    * @param [expectedAction] {string} the capability action that is expected
    *   when validating a proof.
    * @param [caveat] {object or array} one or more Caveat instances that
@@ -50,7 +53,8 @@ module.exports = class CapabilityInvocation extends ControllerProofPurpose {
    */
   constructor({
     expectedTarget, expectedRootCapability, inspectCapabilityChain,
-    capability, capabilityAction, expectedAction, currentDate, caveat,
+    capability, capabilityAction, invocationTarget,
+    expectedAction, currentDate, caveat,
     suite, controller, date, maxTimestampDelta = Infinity, maxChainLength,
     allowTargetAttenuation = false
   } = {}) {
@@ -59,6 +63,7 @@ module.exports = class CapabilityInvocation extends ControllerProofPurpose {
     this.expectedRootCapability = expectedRootCapability;
     this.capability = capability;
     this.capabilityAction = capabilityAction;
+    this.invocationTarget = invocationTarget;
     this.expectedAction = expectedAction;
     this.inspectCapabilityChain = inspectCapabilityChain;
     this.maxChainLength = maxChainLength;
@@ -150,16 +155,20 @@ module.exports = class CapabilityInvocation extends ControllerProofPurpose {
   }
 
   async update(proof) {
-    const {capability, capabilityAction} = this;
+    const {capability, capabilityAction, invocationTarget} = this;
     if(!capability) {
       throw new Error('"capability" is required.');
     }
     if(capabilityAction && typeof capabilityAction !== 'string') {
       throw new TypeError('"capabilityAction" must be a string.');
     }
+    if(!invocationTarget) {
+      throw new Error('"invocationTarget" is required.');
+    }
 
     proof.proofPurpose = 'capabilityInvocation';
     proof.capability = capability;
+    proof.invocationTarget = invocationTarget;
     if(capabilityAction) {
       proof.capabilityAction = capabilityAction;
     }
@@ -167,8 +176,18 @@ module.exports = class CapabilityInvocation extends ControllerProofPurpose {
   }
 
   async match(proof, {document, documentLoader, expansionMap}) {
-    const {expectedAction} = this;
-    return await super.match(proof, {document, documentLoader, expansionMap}) &&
-      (expectedAction === proof.capabilityAction);
+    const {expectedAction, expectedTarget} = this;
+
+    // ensure basic purpose and expected action match the proof
+    if(!(await super.match(proof, {document, documentLoader, expansionMap}) &&
+      (expectedAction === proof.capabilityAction))) {
+      return false;
+    }
+
+    // ensure the proof's declared invocation target matches an expected one
+    if(Array.isArray(expectedTarget)) {
+      return expectedTarget.includes(proof.invocationTarget);
+    }
+    return expectedTarget === proof.invocationTarget;
   }
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@digitalbazaar/security-context": "^1.0.0",
     "jsonld": "^5.2.0",
-    "jsonld-signatures": "^9.0.2",
+    "jsonld-signatures": "^9.2.0",
     "zcap-context": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@digitalbazaar/security-context": "^1.0.0",
     "jsonld": "^5.2.0",
-    "jsonld-signatures": "^9.2.0",
+    "jsonld-signatures": "digitalbazaar/jsonld-signatures#enable-n-purposes",
     "zcap-context": "^1.1.0"
   },
   "devDependencies": {

--- a/tests/mock-data.js
+++ b/tests/mock-data.js
@@ -64,6 +64,13 @@ capabilities.root.beta = {
   controller: controllers.alice.id
 };
 
+capabilities.root.restful = {
+  '@context': zcapld.constants.ZCAP_CONTEXT_URL,
+  id: `urn:zcap:root:${encodeURIComponent('https://zcap.example')}`,
+  controller: controllers.alice.id,
+  invocationTarget: 'https://zcap.example'
+};
+
 capabilities.delegated = {};
 capabilities.delegated.alpha =
   require('./mock-documents/delegated-ocap-root-alpha');
@@ -131,6 +138,7 @@ const docsForLoader = [
   didDocs.delta,
   capabilities.root.alpha,
   capabilities.root.beta,
+  capabilities.root.restful,
   ...keyList
 ];
 

--- a/tests/mock-documents/example-doc-with-alpha-invocation.js
+++ b/tests/mock-documents/example-doc-with-alpha-invocation.js
@@ -6,7 +6,8 @@ module.exports = {
     "type": "Ed25519Signature2018",
     "created": "2018-02-13T21:26:08Z",
     "capability": "https://example.org/alice/caps#1",
-    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..BRtc_VU1Txb-wGVq1VqTLXjPQQCeT7xj8BidGh8DdW0Z-6g0DCvPY_FH7sHRrphlmIRgSe59W4p1YeYLdAjcDg",
+    "invocationTarget": "https://example.org/alice/caps#1",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..nVu3UF6oeDWkbbbvhUe0KCzr6jLzdjHKRpicxB9z04F4X3XIFmFrfCiMIrPlH068HK18g4InUksrlXJbonYyCg",
     "proofPurpose": "capabilityInvocation",
     "verificationMethod": "https://example.com/i/alice/keys/1"
   }

--- a/tests/mock-documents/example-doc-with-beta-invocation.js
+++ b/tests/mock-documents/example-doc-with-beta-invocation.js
@@ -6,7 +6,8 @@ module.exports = {
     "type": "Ed25519Signature2018",
     "created": "2018-02-13T21:26:08Z",
     "capability": "https://example.org/alice/caps#0",
-    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..nW6G_xUHxK49mwimQlcfhSmjGvTc3FcFzopzusBwsz-EYN_WNM4rQWPBcWG6gmLxk9QES1bude5NhSRXWgwVCw",
+    "invocationTarget": "https://example.org/alice/caps#0",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..QyM223BkvuaSE9pLNq9lFbSAa6gI5yEGAZ6a4lGaf25FuDaphDUdzJQLyqA5dSVgcyBDe1GVoPfTN_d7R23UCA",
     "proofPurpose": "capabilityInvocation",
     "verificationMethod": "https://example.com/i/alice/keys/1"
   }

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -905,6 +905,7 @@ describe('zcapld', () => {
           suite: new Ed25519Signature2018(),
           purpose: new CapabilityInvocation({
             expectedTarget: capabilities.root.beta.id,
+            expectedAction: 'write',
             suite: new Ed25519Signature2018()
           }),
           documentLoader: testLoader
@@ -966,7 +967,8 @@ describe('zcapld', () => {
         result.error.name.should.equal('VerificationError');
         const [error] = result.error.errors;
         error.message.should.contain(
-          'action "undefined" does not match the expected capability action');
+          'Could not verify any proofs; no proofs matched the required ' +
+          'suite and purpose.');
       });
 
       it('should fail to verify a capability chain of depth 2 when a ' +
@@ -1022,7 +1024,8 @@ describe('zcapld', () => {
         result.error.name.should.equal('VerificationError');
         const [error] = result.error.errors;
         error.message.should.contain(
-          'action "invalid" is not allowed by the capability');
+          'Could not verify any proofs; no proofs matched the required ' +
+          'suite and purpose.');
       });
 
       it('should verify a capability chain of depth 2 and a ' +
@@ -1068,7 +1071,7 @@ describe('zcapld', () => {
           purpose: new CapabilityInvocation({
             expectedTarget: capabilities.root.beta.id,
             suite: new Ed25519Signature2018(),
-            capabilityAction: 'write'
+            expectedAction: 'write'
           }),
           documentLoader: testLoader
         });
@@ -1119,7 +1122,7 @@ describe('zcapld', () => {
           purpose: new CapabilityInvocation({
             expectedTarget: capabilities.root.beta.id,
             suite: new Ed25519Signature2018(),
-            capabilityAction: 'write'
+            expectedAction: 'write'
           }),
           documentLoader: testLoader
         });
@@ -1175,7 +1178,7 @@ describe('zcapld', () => {
           purpose: new CapabilityInvocation({
             expectedTarget: capabilities.root.beta.id,
             suite: new Ed25519Signature2018(),
-            capabilityAction: 'read'
+            expectedAction: 'read'
           }),
           documentLoader: testLoader
         });


### PR DESCRIPTION
I think I still need to add another fix in `match()` to check expected target in the `proof.capability` before this is ready.